### PR TITLE
Add 'Show unread' action to context menu

### DIFF
--- a/background.js
+++ b/background.js
@@ -176,8 +176,25 @@ async function setupAlarm() {
         {'delayInMinutes': delay, 'periodInMinutes': interval})
 }
 
+async function onContextAction(actionInfo) {
+    if (actionInfo.menuItemId === 'miniflux-show-unread') {
+        var settings = await browser.storage.local.get(['url'])
+        if (!settings.url) {
+            return
+        }
+        browser.tabs.create({url: `${settings.url}/unread`})
+    }
+}
+
 setDefaults()
 browser.browserAction.setBadgeBackgroundColor({'color': 'blue'})
 browser.browserAction.onClicked.addListener(checkFeeds)
 setupAlarm()
 browser.alarms.onAlarm.addListener(handleAlarm)
+
+browser.contextMenus.create({
+    id: 'miniflux-show-unread',
+    title: 'Show unread',
+    contexts: ['browser_action']
+})
+browser.contextMenus.onClicked.addListener(info => onContextAction(info))

--- a/manifest.json
+++ b/manifest.json
@@ -36,5 +36,5 @@
     "page": "options.html"
   },
 
-  "permissions": ["alarms", "<all_urls>", "notifications", "storage"]
+  "permissions": ["alarms", "<all_urls>", "notifications", "storage", "contextMenus"]
 }


### PR DESCRIPTION
Here I added context menu action which opens new browser tab at 'Unread' page. Maybe other users of this extension find it useful too.