### PR TITLE
Add support for API token authorization

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,7 +6,8 @@ var defaults = {
     'password': '',
     'url': '',
     'username': '',
-    'useIcons': true
+    'useIcons': true,
+    'token': ''
 }
 
 async function setDefaults() {
@@ -40,12 +41,19 @@ function sanitizeInterval(settings) {
 async function checkFeeds() {
     var info = await browser.storage.local.get([
         'url', 'username', 'password', 'lastEntry', 'notifications',
-        'maxNotifications', 'useIcons'])
+        'maxNotifications', 'useIcons', 'token'])
 
     var url = info.url + '/v1/entries?status=unread&direction=desc'
+
     var headers = new Headers()
-    headers.append('Authorization',
-        'Basic ' + btoa(`${info.username}:${info.password}`))
+
+    if (info.token) {
+        headers.append('X-Auth-Token', info.token)
+    } else {
+        headers.append('Authorization',
+            'Basic ' + btoa(`${info.username}:${info.password}`))
+    }
+
     var response = await fetch(url, {credentials: 'include', headers: headers})
     var body = await response.json()
 

--- a/options.html
+++ b/options.html
@@ -9,10 +9,31 @@
     <table>
       <tr>
         <td>
+          <strong>Connection settings</strong>
+        </td>
+      </tr>
+
+      <tr>
+        <td>
             <label>Miniflux URL </label> 
         </td>
         <td>
           <input type="url" id="url" ></label>
+        </td>
+      </tr>
+
+      <tr>
+        <td>
+            <label>Miniflux API token </label>
+        </td>
+        <td>
+          <input type="text" id="token" >
+        </td>
+      </tr>
+
+      <tr>
+        <td>
+          - or -
         </td>
       </tr>
 
@@ -31,6 +52,12 @@
         </td>
         <td>
           <input type="password" id="password" ></label>
+        </td>
+      </tr>
+
+      <tr>
+        <td>
+          <strong>Extension settings</strong>
         </td>
       </tr>
 

--- a/options.js
+++ b/options.js
@@ -1,5 +1,5 @@
 var optionNames = ['interval', 'lastEntry', 'maxNotifications',
-    'notifications', 'password', 'url', 'username', 'useIcons']
+    'notifications', 'password', 'url', 'username', 'useIcons', 'token']
 
 function saveOptions(e) {
     e.preventDefault()


### PR DESCRIPTION
Support for API tokens was added in the latest release of Miniflux (2.0.21)

I added two "categories" to the settings in order to better separate token from user/pass without making a larger overhaul.