### PR TITLE
Button to add current page's feed to miniflux

### DIFF
--- a/background.js
+++ b/background.js
@@ -239,6 +239,7 @@ async function onContextAction(actionInfo) {
 }
 
 setDefaults()
+checkFeeds()
 browser.browserAction.setBadgeBackgroundColor({ color: 'royalblue' })
 browser.browserAction.onClicked.addListener(checkFeeds)
 setupAlarm()

--- a/background.js
+++ b/background.js
@@ -222,6 +222,17 @@ async function onContextAction(actionInfo) {
             return
         }
         browser.tabs.create({url: `${settings.url}/unread`})
+    if (actionInfo.menuItemId === 'miniflux-add-feed') {
+        var settings = await browser.storage.local.get(['url'])
+        if (!settings.url) {
+            return
+        }
+        add_feed_url = settings.url + '/bookmarklet?uri='
+        current_url = await browser.tabs.executeScript({
+            code: `window.location.href;`,
+        })
+        current_uri = encodeURIComponent(current_url)
+        browser.tabs.create({ url: add_feed_url + current_uri })
     }
 }
 
@@ -235,5 +246,9 @@ browser.contextMenus.create({
     id: 'miniflux-show-unread',
     title: 'Show unread',
     contexts: ['browser_action']
+browser.contextMenus.create({
+    id: 'miniflux-add-feed',
+    title: 'Add Feed',
+    contexts: ['browser_action'],
 })
 browser.contextMenus.onClicked.addListener(info => onContextAction(info))

--- a/background.js
+++ b/background.js
@@ -68,12 +68,13 @@ async function checkFeeds() {
     }
     var body = await response.json()
 
-    browser.browserAction.setBadgeText({'text': `${body.total}`})
+    browser.browserAction.setBadgeText({'text': ''})
     browser.browserAction.setTitle({title: 'Miniflux Checker'})
     browser.browserAction.setBadgeBackgroundColor({ color: 'royalblue' })
 
     var previousLastEntry = info.lastEntry
     if (body.total > 0) {
+        browser.browserAction.setBadgeText({'text': `${body.total}`})
         var lastEntry = info.lastEntry
         for (let idx=0; idx<body.entries.length; idx++) {
             lastEntry = Math.max(body.entries[idx].id, lastEntry)

--- a/background.js
+++ b/background.js
@@ -62,15 +62,15 @@ async function checkFeeds() {
     }
     if (bad_request || !response.ok) {
         browser.browserAction.setBadgeText({'text': 'X'})
-        browser.browserAction.setBadgeBackgroundColor({color: 'red'})
         browser.browserAction.setTitle({title: 'Miniflux Checker [Error connecting to Miniflux]'})
+        browser.browserAction.setBadgeBackgroundColor({ color: 'crimson' })
         return
     }
     var body = await response.json()
 
     browser.browserAction.setBadgeText({'text': `${body.total}`})
-    browser.browserAction.setBadgeBackgroundColor({color: 'blue'})
     browser.browserAction.setTitle({title: 'Miniflux Checker'})
+    browser.browserAction.setBadgeBackgroundColor({ color: 'royalblue' })
 
     var previousLastEntry = info.lastEntry
     if (body.total > 0) {
@@ -222,6 +222,7 @@ async function onContextAction(actionInfo) {
             return
         }
         browser.tabs.create({url: `${settings.url}/unread`})
+    }
     if (actionInfo.menuItemId === 'miniflux-add-feed') {
         var settings = await browser.storage.local.get(['url'])
         if (!settings.url) {
@@ -237,18 +238,19 @@ async function onContextAction(actionInfo) {
 }
 
 setDefaults()
-browser.browserAction.setBadgeBackgroundColor({'color': 'blue'})
+browser.browserAction.setBadgeBackgroundColor({ color: 'royalblue' })
 browser.browserAction.onClicked.addListener(checkFeeds)
 setupAlarm()
 browser.alarms.onAlarm.addListener(handleAlarm)
 
 browser.contextMenus.create({
     id: 'miniflux-show-unread',
-    title: 'Show unread',
+    title: 'Show Unread',
     contexts: ['browser_action']
+})
 browser.contextMenus.create({
     id: 'miniflux-add-feed',
     title: 'Add Feed',
-    contexts: ['browser_action'],
+    contexts: ['browser_action']
 })
 browser.contextMenus.onClicked.addListener(info => onContextAction(info))

--- a/manifest.json
+++ b/manifest.json
@@ -36,5 +36,5 @@
     "page": "options.html"
   },
 
-  "permissions": ["alarms", "<all_urls>", "notifications", "storage", "contextMenus"]
+  "permissions": ["alarms", "<all_urls>", "notifications", "storage", "contextMenus", "activeTab"]
 }


### PR DESCRIPTION
Miniflux comes with a bookmarklet for adding feeds but I think it's cleaner to have it integrated into this extension and kept on the taskbar.

Doing this required adding activeTab permission.

I also chose some more complimentary badge colours to go with the orange icon and made it so that the badge is only shown if there are new items.